### PR TITLE
Archivinator

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,2 @@
+public
+node_modules

--- a/README.md
+++ b/README.md
@@ -1,1 +1,8 @@
 # webrebels-2016 [![Build Status](https://travis-ci.org/webrebels/web-rebels-2016.svg?branch=master)](https://travis-ci.org/webrebels/web-rebels-2016)
+
+
+# Archived sites
+
+All archived sites are served from this module. The sites are generated as static HTML pages in a gh-pages branch which contains a package.json to allow us to pull them in as dependencies. The we use [vhost](https://github.com/expressjs/vhost) and [connect](https://github.com/senchalabs/connect) to serve up the static sites for the subdomains. This works arround the issue with GitHub not being able to serve TLS for custom domains.
+
+Locally you can test using URLs following this pattern: <year>.localhost:<port>

--- a/bin/app.js
+++ b/bin/app.js
@@ -83,6 +83,7 @@ if (config.get('env') === 'development') {
 }
 
 require('./routes/content')(app);
+require('./routes/archives')(app);
 
 var httpServer = http.createServer(app);
 module.exports = httpServer;

--- a/bin/app.js
+++ b/bin/app.js
@@ -7,13 +7,13 @@ var http                = require('http');
 var config              = require('../config');
 var log                 = require('./log.js');
 
-var helmet              = require('helmet');
-var express             = require('express');
 var bodyParser          = require('body-parser');
-var expressValidator    = require('express-validator');
 var compress            = require('compression')();
-var serveStatic         = require('serve-static');
+var express             = require('express');
+var expressValidator    = require('express-validator');
+var helmet              = require('helmet');
 var hbs                 = require('hbs');
+var serveStatic         = require('serve-static');
 
 var app                 = express();
 var middleSSL           = require('./middleware/ssl.js');
@@ -82,8 +82,9 @@ if (config.get('env') === 'development') {
     app.get('/js/app.js', routeAssets.appJs);
 }
 
-require('./routes/content')(app);
 require('./routes/archives')(app);
+
+require('./routes/content')(app);
 
 var httpServer = http.createServer(app);
 module.exports = httpServer;

--- a/bin/app.js
+++ b/bin/app.js
@@ -5,7 +5,6 @@
 var path                = require('path');
 var http                = require('http');
 var config              = require('../config');
-var log                 = require('./log.js');
 
 var bodyParser          = require('body-parser');
 var compress            = require('compression')();

--- a/bin/routes/archives.js
+++ b/bin/routes/archives.js
@@ -1,6 +1,10 @@
 
+var vhost = require('vhost');
+var connect = require('connect');
+var servestatic = require('serve-static')
 
 module.exports = (app) => {
-  app.use('/2012', require('express').static('./node_modules/web-rebels-2012/'));
-  app.use('/2013', require('express').static('./node_modules/web-rebels-2013/'));
+  ['2012', '2013', '2014', '2015'].map((year) => {
+    app.use(vhost(`${year}.webrebels.org`, connect().use(servestatic(`./node_modules/web-rebels-${year}/`))));
+  });
 };

--- a/bin/routes/archives.js
+++ b/bin/routes/archives.js
@@ -1,0 +1,6 @@
+
+
+module.exports = (app) => {
+  app.use('/2012', require('express').static('./node_modules/web-rebels-2012/'));
+  app.use('/2013', require('express').static('./node_modules/web-rebels-2013/'));
+};

--- a/bin/routes/archives.js
+++ b/bin/routes/archives.js
@@ -2,9 +2,13 @@
 var vhost = require('vhost');
 var connect = require('connect');
 var servestatic = require('serve-static')
+var config = require('../../config');
 
 module.exports = (app) => {
   ['2012', '2013', '2014', '2015'].map((year) => {
     app.use(vhost(`${year}.webrebels.org`, connect().use(servestatic(`./node_modules/web-rebels-${year}/`))));
+    if (config.get('env') === 'development') {
+      app.use(vhost(`${year}.localhost`, connect().use(servestatic(`./node_modules/web-rebels-${year}/`))));
+    }
   });
 };

--- a/config/production.json
+++ b/config/production.json
@@ -1,0 +1,4 @@
+{
+    "logConsoleLevel"   : "info",
+    "docRoot" 			: "/public"
+}

--- a/package.json
+++ b/package.json
@@ -78,6 +78,8 @@
     "react": "^0.14.2",
     "react-dom": "^0.14.2",
     "serve-static": "^1.10.0",
-    "winston": "^1.0.2"
+    "winston": "^1.0.2",
+    "web-rebels-2012": "git://github.com/webrebels/web-rebels-2012#gh-pages",
+    "web-rebels-2013": "git://github.com/webrebels/web-rebels-2013#gh-pages"
   }
 }

--- a/package.json
+++ b/package.json
@@ -47,7 +47,6 @@
     "url": "https://github.com/webrebels/web-rebels-2016/issues"
   },
   "licenses": [],
-  "subdomain": "wr2016",
   "domains": [
     "www.webrebels.org",
     "webrebels.org"
@@ -68,6 +67,7 @@
     "browserify": "^11.2.0",
     "combined-stream": "^1.0.5",
     "compression": "^1.6.0",
+    "connect": "^3.4.0",
     "convict": "^1.0.1",
     "express": "^4.13.3",
     "express-validator": "^2.17.1",
@@ -78,8 +78,11 @@
     "react": "^0.14.2",
     "react-dom": "^0.14.2",
     "serve-static": "^1.10.0",
-    "winston": "^1.0.2",
+    "vhost": "^3.0.2",
     "web-rebels-2012": "git://github.com/webrebels/web-rebels-2012#gh-pages",
-    "web-rebels-2013": "git://github.com/webrebels/web-rebels-2013#gh-pages"
+    "web-rebels-2013": "git://github.com/webrebels/web-rebels-2013#gh-pages",
+    "web-rebels-2014": "git://github.com/webrebels/web-rebels-2014#gh-pages",
+    "web-rebels-2015": "git://github.com/webrebels/web-rebels-2015#gh-pages",
+    "winston": "^1.0.2"
   }
 }

--- a/src/js/script.js
+++ b/src/js/script.js
@@ -1,1 +1,1 @@
-console.log('w000t');
+'use strict';


### PR DESCRIPTION
This PR pulls the archiving into the active module which serves the static pages from the gh-pages branch. This allows us to have TLS on all domains and not have to setup additional stuff.

The whole archiving thing could be moved into a separate module later on as to not have to configure this every year.
