### PR TITLE
Add a buytickets url with a redirect to tito

### DIFF
--- a/bin/pages.js
+++ b/bin/pages.js
@@ -106,7 +106,9 @@ router.get('/scholarship/donate', (req, res, next) => {
     });
 });
 
-
+router.get('/buytickets', (req, res, next) => {
+  res.redirect('https://ti.to/webrebels/2016');
+});
 
 router.post('/scholarship/donate', (req, res, next) => {
     //let stripe = require('stripe')(config.get('stripeSecretApiKey'));


### PR DESCRIPTION
@trygve-lie what do you think about this?

We add this route so we can share the url https://www.webrebels.org/buytickets that way we always can control where we send people. Right now we want to send them to this page https://ti.to/webrebels/2016 but if that were to change we at least have the option.
